### PR TITLE
.toLocaleLowerCase() e.key events

### DIFF
--- a/src/lib/components/Player.svelte
+++ b/src/lib/components/Player.svelte
@@ -155,7 +155,7 @@
       e.preventDefault();
       if ($paintMode) return;
       const mapping = keyMapping[$selectedKeyboard];
-      switch (e.key.toLocaleLowerCase()) {
+      switch (e.key.toLowerCase()) {
         case mapping.backward:
           backward = 1;
           break;
@@ -179,7 +179,7 @@
     function onKeyUp(e: KeyboardEvent) {
       e.preventDefault();
       const mapping = keyMapping[$selectedKeyboard];
-      switch (e.key.toLocaleLowerCase()) {
+      switch (e.key.toLowerCase()) {
         case mapping.backward:
           backward = 0;
           break;

--- a/src/lib/components/Player.svelte
+++ b/src/lib/components/Player.svelte
@@ -152,9 +152,10 @@
     }
   
     function onKeyDown(e: KeyboardEvent) {
+      e.preventDefault();
       if ($paintMode) return;
       const mapping = keyMapping[$selectedKeyboard];
-      switch (e.key) {
+      switch (e.key.toLocaleLowerCase()) {
         case mapping.backward:
           backward = 1;
           break;
@@ -176,8 +177,9 @@
     }
   
     function onKeyUp(e: KeyboardEvent) {
-      const mapping = keyMapping[$selectedKeyboard]; 
-      switch (e.key) {
+      e.preventDefault();
+      const mapping = keyMapping[$selectedKeyboard];
+      switch (e.key.toLocaleLowerCase()) {
         case mapping.backward:
           backward = 0;
           break;

--- a/src/lib/components/PointerLockControls.svelte
+++ b/src/lib/components/PointerLockControls.svelte
@@ -88,6 +88,7 @@
     }
 
     function onKeyDown(event: KeyboardEvent) {
+      event.preventDefault()
       if (event.key === 'e') {
         if (isLocked) {
           unlock()


### PR DESCRIPTION
When a user inputs a keyboard event with SHIFT or CAPSLOCK the keyboard event is W instead of w. 